### PR TITLE
Construct mapping using `aes()`

### DIFF
--- a/R/operation-adjust.R
+++ b/R/operation-adjust.R
@@ -23,7 +23,7 @@ setMethod("apply_operation", signature(operation = "adjust"), function(operation
 
     l$mapping[names(mapping)] = mapping
     if (!is.null(l$mapping)) {
-      class(l$mapping) = "uneval"
+      l$mapping = aes(!!!l$mapping)
     }
 
     aes_param_names = intersect(names(params), l$geom$aesthetics())


### PR DESCRIPTION
Hi Matthew,

We're updating ggplot2 to have S7 classes, which causes an incompatibility with ggblend found through reverse dependency checks.
In essence, we'd have to construct the plot mapping with `aes()` rather than assigning the 'uneval' class. There might also be some visual changes, though I'm not sure whether I detected platform specific changes on my end.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun